### PR TITLE
Fix message state reset and SingleChat rendering

### DIFF
--- a/frontend/src/components/chat/allChats.jsx
+++ b/frontend/src/components/chat/allChats.jsx
@@ -96,7 +96,7 @@ function AllChats() {
           );
         })
       ) : (
-        <p>No chats available</p>
+        <p>No chats to display</p>
       )}
     </div>
   );

--- a/frontend/src/components/chat/singleChat.jsx
+++ b/frontend/src/components/chat/singleChat.jsx
@@ -44,6 +44,7 @@ function SingleChat({ chat, friend, onUpdateChat }) {
 
   useEffect(() => {
     if (chat && chat.id && !chat.isLocked) {
+      setMessages([]);
       api
         .get(`/messages/${chat.id}`)
         .then((response) => {
@@ -52,6 +53,8 @@ function SingleChat({ chat, friend, onUpdateChat }) {
           }
         })
         .catch((err) => console.error("Error fetching messages:", err));
+    } else {
+      setMessages([]);
     }
   }, [chat]);
 
@@ -210,16 +213,17 @@ function SingleChat({ chat, friend, onUpdateChat }) {
         ref={containerRef}
         className="flex-grow overflow-y-auto pl-5 pr-6 pt-5 pb-3 bg-gray-100 dark:bg-[#212529]  space-y-2 pb-24 "
       >
-        {messages.map((msg, index) => (
-          <Message
-            key={`${msg.id}-${index}`}
-            message={msg}
-            isGroup={chat.isGroup}
-            isOwnMessage={msg.senderId === currentUserId}
-            onReact={handleReaction}
-            onShowReactions={(messageId) => setReactionsPopup(messageId)}
-          />
-        ))}
+        {messages &&
+          messages.map((msg, index) => (
+            <Message
+              key={`${msg.id}-${index}`}
+              message={msg}
+              isGroup={chat.isGroup}
+              isOwnMessage={msg.senderId === currentUserId}
+              onReact={handleReaction}
+              onShowReactions={(messageId) => setReactionsPopup(messageId)}
+            />
+          ))}
         <div ref={messagesEndRef} />
         {reactionsPopup && (
           <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50">

--- a/frontend/src/pages/chatPage.jsx
+++ b/frontend/src/pages/chatPage.jsx
@@ -80,6 +80,7 @@ function ChatPage() {
                 {/* Single Chat Container with scroll */}
                 <div className="flex-grow overflow-y-auto">
                   <SingleChat
+                    key={activeChat.id}
                     chat={activeChat}
                     friend={friend}
                     onUpdateChat={setActiveChat} //will update the activeChat, from returned lockedChat/unlockedChat apis


### PR DESCRIPTION
Resets messages state when chat changes or is locked in SingleChat to prevent stale messages. Adds key prop to SingleChat in chatPage to ensure proper re-rendering when activeChat changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat component rendering when switching between conversations
  
* **Style**
  * Updated empty state message in the chat interface

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->